### PR TITLE
Confine all execution of facts to Windows

### DIFF
--- a/lib/facter/win_dotnet35_version.rb
+++ b/lib/facter/win_dotnet35_version.rb
@@ -1,16 +1,17 @@
 Facter.add("win_dotnet35_version") do
   confine :osfamily => "windows"
-  
-  ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
-  ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.5').Version; If (!$psq) { echo 'false' } else { echo $psq }"
-  ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
-
   setcode do
+    ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+    ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.5').Version; If (!$psq) { echo 'false' } else { echo $psq }"
+    ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
+
     case ps_cmd
       when 'false'
         answer='notinstalled'
       else
         answer=ps_cmd
     end
+
+    answer
   end
 end

--- a/lib/facter/win_dotnet3_version.rb
+++ b/lib/facter/win_dotnet3_version.rb
@@ -1,16 +1,17 @@
 Facter.add("win_dotnet3_version") do
   confine :osfamily => "windows"
-  
-  ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
-  ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.0').Version; If (!$psq) { echo 'false' } else { echo $psq }"
-  ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
-
   setcode do
+    ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+    ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v3.0').Version; If (!$psq) { echo 'false' } else { echo $psq }"
+    ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
+
     case ps_cmd
       when 'false'
         answer='notinstalled'
       else
         answer=ps_cmd
     end
+
+    answer
   end
 end

--- a/lib/facter/win_dotnet4_version.rb
+++ b/lib/facter/win_dotnet4_version.rb
@@ -1,11 +1,10 @@
 Facter.add("win_dotnet4_version") do
   confine :osfamily => "windows"
-  
-  ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
-  ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v4\\Full' Release).Release; If (!$psq) { echo 'false' } else { echo $psq }"
-  ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
-
   setcode do
+    ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+    ps_query = "$psq=(Get-ItemProperty -ErrorAction SilentlyContinue 'HKLM:\\Software\\Microsoft\\Net Framework Setup\\NDP\\v4\\Full' Release).Release; If (!$psq) { echo 'false' } else { echo $psq }"
+    ps_cmd   = (Facter::Util::Resolution.exec(%Q{#{ps_exec} -command "#{ps_query}"})).strip
+
     case ps_cmd
       when 'false'
         answer='notinstalled'
@@ -20,5 +19,7 @@ Facter.add("win_dotnet4_version") do
       else
         answer='unknown'
     end
+
+    answer
   end
 end

--- a/lib/facter/win_powershell_version.rb
+++ b/lib/facter/win_powershell_version.rb
@@ -1,10 +1,10 @@
 Facter.add("win_dotnet4_version") do
   confine :osfamily => "windows"
-  
-  ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
-  ps_cmd   = '($PSVersionTable.Version).Major'
 
   setcode do
+    ps_exec  = 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+    ps_cmd   = '($PSVersionTable.Version).Major'
+
     Facter::Util::Resolution.exec(%Q{#{ps_exec} -command #{ps_cmd}}).strip
   end
 end


### PR DESCRIPTION
Ensure that custom facts only attempt to execute
code on Windows by moving all execution into
`setcode`. Ensure answer is still returned as the
output for the variable.

Closes #5.
